### PR TITLE
Fixed issue in code that was setting uid twice.

### DIFF
--- a/src/front/js/store/flux.js
+++ b/src/front/js/store/flux.js
@@ -20,12 +20,10 @@ const getState = ({ getStore, getActions, setStore }) => {
         })
         
         .then(res => res.json())
-        .then(data => {
-          console.log("This is the getUser", data)
-          setStore({uid: data})
-        })
+        .then(data => { console.log(data)})
         .catch(err => console.log(err))
       },
+      
       getFavorites: (token) => {
         fetch(process.env.BACKEND_URL + '/api/albums',{
           method: 'GET',


### PR DESCRIPTION
it should be set only once. It was being set in two different flux actions which cause some weird issues with route to the profile where it sometimes would return [Object Object].

Changed it to be set only once and now it seems to have fixed the bug. 