### PR TITLE
Fixed issue in code that was setting uid twice.

### DIFF
--- a/src/front/js/store/flux.js
+++ b/src/front/js/store/flux.js
@@ -20,12 +20,10 @@ const getState = ({ getStore, getActions, setStore }) => {
         })
         
         .then(res => res.json())
-        .then(data => {
-          console.log("This is the getUser", data)
-          setStore({uid: data})
-        })
+        .then(data => { console.log(data)})
         .catch(err => console.log(err))
       },
+      
       getFavorites: (token) => {
         fetch(process.env.BACKEND_URL + '/api/albums',{
           method: 'GET',


### PR DESCRIPTION
Fixed a bug that would redirect to `profile/[Object Object]`. 

This was caused by the uid being setting twice in the flux.js file.